### PR TITLE
Add build tag and appropriate LDFLAGS for macOS support

### DIFF
--- a/openfhe.go
+++ b/openfhe.go
@@ -5,7 +5,8 @@ package openfhe
 /*
 #cgo CFLAGS:   -I/usr/local/include -I/usr/local/include/openfhe/core -I/usr/local/include/openfhe/pke -I/usr/local/include/openfhe/ -I/usr/local/include/openfhe/binfhe
 #cgo CXXFLAGS: -I/usr/local/include -I/usr/local/include/openfhe/core -I/usr/local/include/openfhe/pke -I/usr/local/include/openfhe/ -I/usr/local/include/openfhe/binfhe -std=c++17
-#cgo LDFLAGS:  -lOPENFHEcore -lOPENFHEpke -lstdc++ -lm -lpthread
+#cgo darwin LDFLAGS:  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lOPENFHEcore -lOPENFHEpke -lstdc++ -lm -lpthread
+#cgo linux LDFLAGS:  -lOPENFHEcore -lOPENFHEpke -lstdc++ -lm -lpthread
 #include "openfhe_c.h"          // header only – no .cpp here
 */
 import "C"


### PR DESCRIPTION
OpenFHE provides [macOS support](https://openfhe-development.readthedocs.io/en/latest/sphinx_rsts/intro/installation/macos.html).

After building OpenFHE on macOS I've noticed that current `main` branch doesn't build on macOS:

```
% go test . -tags 'openfhe'                                               
# github.com/collapsinghierarchy/openfhe-go.test
ld: warning: ignoring duplicate libraries: '-lc++'
dyld[48543]: Library not loaded: @rpath/libOPENFHEcore.1.dylib
  Referenced from: <A2C383E2-3C60-3420-FB90-F4D5EFC96691> /private/var/folders/s5/3_m33khx5njfpz_5g1d4wrkc0000gn/T/go-build1261414508/b001/openfhe-go.test
  Reason: no LC_RPATH's found
signal: abort trap
FAIL	github.com/collapsinghierarchy/openfhe-go	0.310s
FAIL
```

The change adds `-Wl,-rpath,/usr/local/lib` to macOS (darwin) linker flags, macOS 10.5 and above use/expect `rpath` for search path:

```
% go test . -tags 'openfhe'
# github.com/collapsinghierarchy/openfhe-go.test
ld: warning: ignoring duplicate libraries: '-lc++'
ok  	github.com/collapsinghierarchy/openfhe-go	0.328s
```

The introduction of these linker flags enable macOS support for `openfhe-go` and the usage of the `darwin` build tag will ensure they're only used for macOS builds 👍 